### PR TITLE
Deploy an internal load balancer to keep Gitaly traffic inside VPC

### DIFF
--- a/templates/workload/gitlab-postinstall-template.yaml
+++ b/templates/workload/gitlab-postinstall-template.yaml
@@ -88,6 +88,18 @@ Resources:
       Name: !Sub 'service/${HelmChartName}-nginx-ingress-controller'
       JsonPath: '{.status.loadBalancer.ingress[0].hostname}'
       Retries: 3
+  InternalLoadBalancerQuery:
+    Type: AWSQS::Kubernetes::Get
+    # Dependency to ensure queries are not executed in parallel - seen some errors when they run concurrently
+    DependsOn: LoadBalancerQuery
+    # E3001 Invalid or unsupported Type AWSQS::Kubernetes::Get
+    Metadata: { cfn-lint: { config: { ignore_checks: [E3001] } } }
+    Properties:
+      ClusterName: !Ref ClusterName
+      Namespace: !Ref HelmChartNamespace
+      Name: !Sub 'service/${HelmChartName}-nginx-ingress-controller-internal'
+      JsonPath: '{.status.loadBalancer.ingress[0].hostname}'
+      Retries: 3
   LoadBalancerParameter:
     Type: AWS::SSM::Parameter
     Properties:
@@ -100,7 +112,7 @@ Resources:
   RootCAQuery:
     Type: AWSQS::Kubernetes::Get
     # Dependency to ensure queries are not executed in parallel - seen some errors when they run concurrently
-    DependsOn: LoadBalancerQuery
+    DependsOn: InternalLoadBalancerQuery
     # E3001 Invalid or unsupported Type AWSQS::Kubernetes::Get
     Metadata: { cfn-lint: { config: { ignore_checks: [E3001] } } }
     Properties:
@@ -149,7 +161,7 @@ Resources:
       Type: CNAME
       TTL: 900
       ResourceRecords:
-        - !GetAtt  LoadBalancerQuery.Response
+        - !GetAtt  InternalLoadBalancerQuery.Response
   GitLabDNSRecord:
     Type: AWS::Route53::RecordSet
     Condition: RegisterDns
@@ -170,7 +182,7 @@ Resources:
       Type: CNAME
       TTL: 900
       ResourceRecords:
-        - !GetAtt  LoadBalancerQuery.Response
+        - !GetAtt  InternalLoadBalancerQuery.Response
   RegistryDNSRecord:
     Type: AWS::Route53::RecordSet
     Condition: RegisterDns

--- a/templates/workload/gitlab-praefect-template.yaml
+++ b/templates/workload/gitlab-praefect-template.yaml
@@ -28,9 +28,9 @@ Parameters:
     AllowedPattern: "[a-zA-Z0-9]*"
     MaxLength: "64"
     MinLength: "0"
-  DBMasterUsername:
+  DBUsername:
     Type: String
-  DBMasterUserPassword:
+  DBUserPassword:
     Type: String
     NoEcho: "True"
 
@@ -134,8 +134,8 @@ Resources:
     Properties:
       Host: !Ref DBHost
       DBName: !Ref DBName
-      UserName: !Ref DBMasterUsername
-      Password: !Ref DBMasterUserPassword
+      UserName: !Ref DBUsername
+      Password: !Ref DBUserPassword
       ServiceToken: !GetAtt CreateDatabaseLambda.Arn
 
   EC2InstanceProfile:
@@ -310,8 +310,8 @@ Resources:
 
                 praefect['database_host'] = '${DBHost}'
                 praefect['database_port'] = '${DBPort}'
-                praefect['database_user'] = '${DBMasterUsername}'
-                praefect['database_password'] = '${DBMasterUserPassword}'
+                praefect['database_user'] = '${DBUsername}'
+                praefect['database_password'] = '${DBUserPassword}'
                 praefect['database_dbname'] = '${DBName}'
                 praefect['database_sslmode'] = 'require'
 

--- a/templates/workload/gitlab-template.yaml
+++ b/templates/workload/gitlab-template.yaml
@@ -317,8 +317,8 @@ Resources:
         DBHost: !GetAtt Database.Outputs.RDSEndPointAddress
         DBPort: !Ref DBPort
         DBName: !Ref DBPraefectName
-        DBMasterUsername: !Sub "{{resolve:secretsmanager:${Infrastructure.Outputs.DatabaseSecretName}:SecretString:username}}"
-        DBMasterUserPassword: !Sub "{{resolve:secretsmanager:${Infrastructure.Outputs.DatabaseSecretName}:SecretString:password}}"
+        DBUsername: !Sub "{{resolve:secretsmanager:${Infrastructure.Outputs.DatabaseSecretName}:SecretString:username}}"
+        DBUserPassword: !Sub "{{resolve:secretsmanager:${Infrastructure.Outputs.DatabaseSecretName}:SecretString:password}}"
         VPCID: !Ref VPCID
         DBSubnetIds: !Join [ ',', [ !Ref PrivateSubnet1ID, !Ref PrivateSubnet2ID ] ]
         DBSecurityGroup: !GetAtt Infrastructure.Outputs.DatabaseSecurityGroupID

--- a/templates/workload/gitlab-template.yaml
+++ b/templates/workload/gitlab-template.yaml
@@ -478,7 +478,11 @@ Resources:
                   service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
                   service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "ssl"
                   service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "${SslCertificateArn}"
-
+                # Deploy internal load balancer 
+                internal:
+                  enabled: true
+                  annotations:
+                    service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
         - SslCertificateArn: !If [AcmIngressConfigured, !GetAtt Infrastructure.Outputs.SslCertificateArn, ""]
           
       Values:


### PR DESCRIPTION
*Issue #, if available:* #98

*Description of changes:*
Deploy an internal load balancer to keep Gitaly traffic inside VPC

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
