### PR TITLE
Ensure SMTP domain is created if requested, even if Route53 is not used for DNS

### DIFF
--- a/templates/workload/gitlab-infra-template.yaml
+++ b/templates/workload/gitlab-infra-template.yaml
@@ -280,6 +280,7 @@ Resources:
     Properties:
       Type: String
       Name: !Sub '/quickstart/gitlab/${EnvironmentName}/infra/domain-name'
+      Description: "GitLab domain name"
       Value: !Ref DomainName
 
   HostedZoneNameParameter:
@@ -296,6 +297,7 @@ Resources:
     Properties:
       Type: String
       Name: !Sub '/quickstart/gitlab/${EnvironmentName}/infra/hosted-zone-id'
+      Description: "GitLab Route53 public hosted zone ID"
       Value: !Ref HostedZone
 
   PrivateHostedZoneIdParameter:
@@ -303,6 +305,7 @@ Resources:
     Properties:
       Type: String
       Name: !Sub '/quickstart/gitlab/${EnvironmentName}/infra/private-hosted-zone-id'
+      Description: "GitLab Route53 private hosted zone ID"
       Value: !Ref PrivateHostedZone
 
   CertificateArnParameter:
@@ -311,7 +314,17 @@ Resources:
     Properties:
       Type: String
       Name: !Sub '/quickstart/gitlab/${EnvironmentName}/infra/certificate-arn'
+      Description: "GitLab ACM certificate ARN"
       Value: !Ref SslCertificate
+
+  SmtpDomainValidationEntries:
+    Type: AWS::SSM::Parameter
+    Condition: EmailDomainRequested
+    Properties:
+      Type: String
+      Name: !Sub '/quickstart/gitlab/${EnvironmentName}/infra/smtp-validation-entries'
+      Description: "GitLab SMTP domain validation entries"
+      Value: !Join ["\n", !GetAtt SESDomain.ZoneFileEntries]
 
   SmtpCredentialsSecret:
     Type: 'AWS::SecretsManager::Secret'
@@ -320,14 +333,6 @@ Resources:
       Name: !Sub '/quickstart/gitlab/${EnvironmentName}/infra/smtp-credentials'
       Description: "GitLab SMTP credentials"
       SecretString: !Sub '{"username": "${SmtpKeys}", "password": "${SmtpPasswordGenerator.Password}"}'
-
-  SmtpDomainValidationEntries:
-    Type: AWS::SSM::Parameter
-    Condition: EmailDomainRequested
-    Properties:
-      Name: !Sub '/quickstart/gitlab/${EnvironmentName}/infra/smtp-validation-entries'
-      Description: "GitLab SMTP domain validation entries"
-      Value: !Join ["\n", !GetAtt SESDomain.ZoneFileEntries]
 
 Outputs:
   PraefectSecurityGroupID:

--- a/templates/workload/gitlab-infra-template.yaml
+++ b/templates/workload/gitlab-infra-template.yaml
@@ -52,7 +52,8 @@ Parameters:
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
   HostedZoneRequested: !Equals  [!Ref CreateHostedZone, 'Yes']
-  EmailDomainRequested: !And
+  EmailDomainRequested: !Equals [!Ref CreateEmailDomain, 'Yes']
+  EmailDomainWithRoute53Validation: !And
     - !Equals [!Ref CreateEmailDomain, 'Yes']
     - !Condition HostedZoneRequested
   CertificateRequested: !And
@@ -200,7 +201,7 @@ Resources:
 #    Or if you don't use Route 53, see "Return Values" for other DNS options.)
   Route53RecordsForSES:
     Type: AWS::Route53::RecordSetGroup
-    Condition: EmailDomainRequested
+    Condition: EmailDomainWithRoute53Validation
     Properties:
       HostedZoneId: !Ref HostedZone
       # The Route53RecordSets attribute specifies all DNS records needed:
@@ -319,6 +320,14 @@ Resources:
       Name: !Sub '/quickstart/gitlab/${EnvironmentName}/infra/smtp-credentials'
       Description: "GitLab SMTP credentials"
       SecretString: !Sub '{"username": "${SmtpKeys}", "password": "${SmtpPasswordGenerator.Password}"}'
+
+  SmtpDomainValidationEntries:
+    Type: AWS::SSM::Parameter
+    Condition: EmailDomainRequested
+    Properties:
+      Name: !Sub '/quickstart/gitlab/${EnvironmentName}/infra/smtp-validation-entries'
+      Description: "GitLab SMTP domain validation entries"
+      Value: !Join ["\n", !GetAtt SESDomain.ZoneFileEntries]
 
 Outputs:
   PraefectSecurityGroupID:


### PR DESCRIPTION
*Issue #, if available:* #105

*Description of changes:*
Ensure SMTP domain is created if requested, even if Route53 is not used for DNS. Add SSM parameter to expose DNS entries for SMTP domain validation:

```
/quickstart/gitlab/{EnvironmentName}/infra/smtp-validation-entries
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
