### PR TITLE
AL2 Packages and Graviton Configurable for Gitaly for GitLab 14.9.0 or later

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -75,12 +75,7 @@ tests:
       KeyPairName: eks-quickstart
       GitalyPraefectInstanceArchitecture: x86_64
     regions:
-    - eu-west-1
-    - eu-central-1
-    - us-east-1
-    - us-west-2
     - ap-south-1
-    - ca-central-1
 
 #The cluster cannot use ARM yet - must specific x86 instances.
 #Gitaly must be set to 3 instances
@@ -114,9 +109,4 @@ tests:
       KeyPairName: eks-quickstart
       GitalyPraefectInstanceArchitecture: arm64
     regions:
-    - eu-west-1
-    - eu-central-1
-    - us-east-1
-    - us-west-2
-    - ap-south-1
     - ca-central-1

--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -6,7 +6,7 @@ project:
     KeyPairName: --overridden--
     RemoteAccessCIDR: 127.0.0.1/32
     QSS3BucketName: $[taskcat_autobucket]
-    QSS3BucketRegion: $[taskcat_current_region]
+    QSS3BucketRegion: us-east-1
     QSS3KeyPrefix: quickstart-eks-gitlab/
   lambda_source_path: functions/source
   lambda_zip_path: functions/packages
@@ -44,3 +44,82 @@ tests:
       RDSDBInstanceClass: db.t3.small
     regions:
     - eu-central-1
+
+#Gitaly must be set to 3 instances
+#technically running graviton RDS and Elasticache could
+#still be considered x86 because these are PaaS
+  smallest-possible-x86:
+    parameters:
+      AvailabilityZones: $[taskcat_genaz_2]
+      NumberOfAZs: 2
+      EKSPublicAccessEndpoint: Disabled
+      ProvisionBastionHost: Enabled
+      DomainName: qsgsm5.devops4the.cloud
+      CreateSslCertificate: 'Yes'
+      SslCertificateIssuerEmail: gitlab@$[taskcat_random-string].com
+      ConfigureContainerInsights: 'Yes'
+      ConfigureGrafana: 'Yes'
+      CreateHostedZone: 'Yes'
+      SMTPDomain: CreateNew
+      ConfigureRunner: 'No'
+      PriviligedMode: 'No'
+      KeyPairName: eks-quickstart
+      NumberOfNodes: 2
+      NodeInstanceType: t3.medium
+      RDSDBInstanceClass: db.t3.small
+      CacheMode: External
+      CacheNodes: 2
+      CacheNodeType: cache.t3.small
+      NumberOfGitalyReplicas: 3
+      GitalyInstanceType: t3a.small
+      NumberOfPraefectReplicas: 3
+      PraefectInstanceType: t3a.micro
+      KeyPairName: eks-quickstart
+      GitalyPraefectInstanceArchitecture: x86_64
+    regions:
+    - eu-west-1
+    - eu-central-1
+    - us-east-1
+    - us-west-2
+    - ap-south-1
+    - ca-central-1
+
+#The cluster cannot use ARM yet - must specific x86 instances.
+#Gitaly must be set to 3 instances
+#14.9.0 is the first release that has ARM packages for AL2.
+  smallest-possible-arm:
+    parameters:
+      GitLabVersion: 14.9.0
+      AvailabilityZones: $[taskcat_genaz_2]
+      NumberOfAZs: 2
+      EKSPublicAccessEndpoint: Disabled
+      ProvisionBastionHost: Enabled
+      DomainName: qsgsmg3.devops4the.cloud
+      CreateSslCertificate: 'Yes'
+      SslCertificateIssuerEmail: gitlab@$[taskcat_random-string].com
+      ConfigureContainerInsights: 'Yes'
+      ConfigureGrafana: 'Yes'
+      CreateHostedZone: 'Yes'
+      SMTPDomain: CreateNew
+      ConfigureRunner: 'No'
+      PriviligedMode: 'No'
+      KeyPairName: eks-quickstart
+      NumberOfNodes: 2
+      NodeInstanceType: t3.medium
+      RDSDBInstanceClass: db.t4g.small
+      CacheMode: External
+      CacheNodes: 2
+      CacheNodeType: cache.t4g.small
+      NumberOfGitalyReplicas: 3
+      GitalyInstanceType: t4g.small
+      NumberOfPraefectReplicas: 3
+      PraefectInstanceType: t4g.micro
+      KeyPairName: eks-quickstart
+      GitalyPraefectInstanceArchitecture: arm64
+    regions:
+    - eu-west-1
+    - eu-central-1
+    - us-east-1
+    - us-west-2
+    - ap-south-1
+    - ca-central-1

--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -6,7 +6,7 @@ project:
     KeyPairName: --overridden--
     RemoteAccessCIDR: 127.0.0.1/32
     QSS3BucketName: $[taskcat_autobucket]
-    QSS3BucketRegion: us-east-1
+    QSS3BucketRegion: $[taskcat_current_region]
     QSS3KeyPrefix: quickstart-eks-gitlab/
   lambda_source_path: functions/source
   lambda_zip_path: functions/packages

--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -3,7 +3,6 @@ project:
   shorten_stack_name: true
   template: templates/gitlab-entry-new-vpc.template.yaml
   parameters:
-    KeyPairName: --overridden--
     RemoteAccessCIDR: 127.0.0.1/32
     QSS3BucketName: $[taskcat_autobucket]
     QSS3BucketRegion: $[taskcat_current_region]
@@ -63,7 +62,6 @@ tests:
       SMTPDomain: CreateNew
       ConfigureRunner: 'No'
       PriviligedMode: 'No'
-      KeyPairName: eks-quickstart
       NumberOfNodes: 2
       NodeInstanceType: t3.medium
       RDSDBInstanceClass: db.t3.small
@@ -103,7 +101,6 @@ tests:
       SMTPDomain: CreateNew
       ConfigureRunner: 'No'
       PriviligedMode: 'No'
-      KeyPairName: eks-quickstart
       NumberOfNodes: 2
       NodeInstanceType: t3.medium
       RDSDBInstanceClass: db.t4g.small

--- a/templates/gitlab-entry-existing-vpc.template.yaml
+++ b/templates/gitlab-entry-existing-vpc.template.yaml
@@ -112,6 +112,7 @@ Metadata:
       - Label:
           default: GitLab Git repository storage configuration
         Parameters:
+          - GitalyPraefectInstanceArchitecture
           - NumberOfGitalyReplicas
           - GitalyInstanceType
           - GitalyVolumeSize
@@ -246,6 +247,8 @@ Metadata:
       GitLabVersion:
         default: GitLab application version
     # GitLab Git repository storage configuration
+      GitalyPraefectInstanceArchitecture:
+        default: Architecture of Gitaly and Praefect Instances
       GitalyInstanceType:
         default: Gitaly instance type
       NumberOfGitalyReplicas:
@@ -611,10 +614,18 @@ Parameters:
     Default: '14.5.2'
 
 # Gitaly Storage Parameters
+  GitalyPraefectInstanceArchitecture:
+    Type: String
+    Description: |
+      Pick x86_64 or arm64. Architecture of both GitalyInstanceType and PraefectInstanceType must match this arch value.
+      NOTE: ARM for Amazon Linux is not supported before GitLab 14.9.0 and this stack will fail if that combination is specified.
+    Default: x86_64
+    AllowedValues:
+     - x86_64
+     - arm64
   NumberOfGitalyReplicas:
     Type: Number
     Default: 3
-    AllowedValues: [ 3 ]
     Description: |
       Number of Gitaly replicas to deploy in GitLab cluster.
       The replicas will be distributed across Availability Zones selected.
@@ -635,11 +646,9 @@ Parameters:
   NumberOfPraefectReplicas:
     Type: Number
     Default: 3
-    AllowedValues: [ 3 ]
     Description: |
       Praefect coordinates Gitaly cluster replication. Number of Praefect replicas to deploy in GitLab cluster.
       The replicas will be distributed across Availability Zones selected.
-      3 are required because Prafect replicas perform voting for data consistency and so an odd number are needed.
   PraefectInstanceType:
     Type: String
     Default: t3.medium
@@ -888,6 +897,7 @@ Resources:
         HelmChartVersion: !Ref HelmChartVersion
         GitLabVersion: !Ref GitLabVersion
         # Git repository storage properties
+        LatestAmazonLinuxAmi: !Sub '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-${GitalyPraefectInstanceArchitecture}-gp2'
         PraefectInstanceType: !Ref PraefectInstanceType
         GitalyInstanceType: !Ref GitalyInstanceType
         NumberOfPraefectReplicas: !Ref NumberOfPraefectReplicas

--- a/templates/gitlab-entry-new-vpc.template.yaml
+++ b/templates/gitlab-entry-new-vpc.template.yaml
@@ -112,6 +112,7 @@ Metadata:
       - Label: 
           default: GitLab Git repository storage configuration
         Parameters:
+          - GitalyPraefectInstanceArchitecture
           - NumberOfGitalyReplicas
           - GitalyInstanceType
           - GitalyVolumeSize
@@ -248,6 +249,8 @@ Metadata:
       GitLabVersion:
         default: GitLab application version
     # GitLab Git repository storage configuration
+      GitalyPraefectInstanceArchitecture:
+        default: Architecture of Gitaly and Praefect Instances
       GitalyInstanceType:
         default: Gitaly instance type
       NumberOfGitalyReplicas:
@@ -636,9 +639,18 @@ Parameters:
   GitLabVersion:
     Type: String
     Description: Version of GitLab application - must correspond to helm chart version above. See https://docs.gitlab.com/charts/installation/version_mappings.html.
-    Default: '14.5.2'
+    Default: '14.9.0'
 
 # Gitaly Storage Parameters
+  GitalyPraefectInstanceArchitecture:
+    Type: String
+    Description: |
+      Pick x86_64 or arm64. Architecture of both GitalyInstanceType and PraefectInstanceType must match this arch value.
+      NOTE: ARM for Amazon Linux is not supported before GitLab 14.9.0 and this stack will fail if that combination is specified.
+    Default: x86_64
+    AllowedValues:
+     - x86_64
+     - arm64
   NumberOfGitalyReplicas:
     Type: Number
     Default: 3
@@ -667,7 +679,6 @@ Parameters:
     Description: |
       Praefect coordinates Gitaly cluster replication. Number of Praefect replicas to deploy in GitLab cluster.
       The replicas will be distributed across Availability Zones selected.
-      3 are required because Prafect replicas perform voting for data consistency and so an odd number are needed.
   PraefectInstanceType:
     Type: String
     Default: t3.medium
@@ -878,6 +889,7 @@ Resources:
         HelmChartVersion: !Ref HelmChartVersion
         GitLabVersion: !Ref GitLabVersion
         # Gitaly Storage Parameters
+        GitalyPraefectInstanceArchitecture: !Ref GitalyPraefectInstanceArchitecture
         NumberOfGitalyReplicas: !Ref NumberOfGitalyReplicas
         GitalyInstanceType: !Ref GitalyInstanceType
         GitalyVolumeSize: !Ref GitalyVolumeSize

--- a/templates/workload/gitlab-functions-template.yaml
+++ b/templates/workload/gitlab-functions-template.yaml
@@ -45,7 +45,6 @@ Resources:
   DeleteBucketContentsFunction:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub ['${Prefix}-DeleteBucketContents', {Prefix: !FindInMap [Config, GitLabPrefix, Value]}]
       Handler: lambda_function.lambda_handler
       MemorySize: 128
       Role: !GetAtt DeleteBucketContentsRole.Arn

--- a/templates/workload/gitlab-gitaly-template.yaml
+++ b/templates/workload/gitlab-gitaly-template.yaml
@@ -240,7 +240,20 @@ Resources:
           commands:
             100_gitlab_yum_repo:
               command:  curl https://packages.gitlab.com/install/repositories/gitlab/gitlab-ee/script.rpm.sh | bash
-            
+
+            # 105_gitlab_distro_mapping:
+            #   command: !Sub |
+            #     IFS='.' read -r major minor patch <<< '${GitLabVersion}'; if [ ${major} -ge 15 ]; then sed -i 's/\\/el\\/7/\\/amazon\\/2/g' /etc/yum.repos.d/gitlab_gitlab*.repo; else sed -i 's/\\/amazon\\/2/\\/el\\/7/g' /etc/yum.repos.d/gitlab_gitlab*.repo; fi; yum clean all ; yum makecache;
+
+            105_gitlab_distro_mapping:
+              command:
+                Fn::Join:
+                  - ""
+                  - - "echo 'WARNING: ARM for Amazon Linux is not supported before GitLab 14.9.0 and this stack will fail if that combination is specified.'; IFS='.' read -r major minor patch <<< '"
+                    - Ref: "GitLabVersion"
+                    - "'; if [[ ${major} -ge 15 || (${major} -eq 14 && ${minor} -ge 9) ]]; then sed -i 's/\\/el\\/7/\\/amazon\\/2/g' /etc/yum.repos.d/gitlab_gitlab*.repo; else sed -i 's/\\/amazon\\/2/\\/el\\/7/g' /etc/yum.repos.d/gitlab_gitlab*.repo; fi; yum clean all ; yum makecache;"
+#                    - "'; if [[ ${major} -ge 14 ]]; then sed -i 's/\\/el\\/7/\\/amazon\\/2/g' /etc/yum.repos.d/gitlab_gitlab*.repo; else sed -i 's/\\/amazon\\/2/\\/el\\/7/g' /etc/yum.repos.d/gitlab_gitlab*.repo; fi; yum clean all ; yum makecache;"
+
             200_update_yum:
               command: yum update -y --exclude=gitlab-ee*
 
@@ -271,7 +284,8 @@ Resources:
                 gitlab_workhorse['enable'] = false
                 gitaly['enable'] = true
                 grafana['enable'] = false
-                
+                gitlab_kas['enable'] = false
+
                 ## Prevent database connections during 'gitlab-ctl reconfigure'
                 gitlab_rails['rake_cache_clear'] = false
                 gitlab_rails['auto_migrate'] = false
@@ -282,7 +296,7 @@ Resources:
 
                 gitaly['auth_token'] = '${PraefectInternalToken}'
                 gitlab_shell['secret_token'] = '${GitLabShellToken}'
-                
+
                 git_data_dirs({
                   "gitaly-0" => {
                     "path" => "/gitlab-data"
@@ -308,11 +322,11 @@ Resources:
                 mount /dev/sdg /gitlab-data
                 echo "/dev/sdg /gitlab-data ext4 defaults 0 0" >> /etc/fstab
                 chown -R git:git /gitlab-data/
-                
+
               mode: "000700"
               owner: root
               group: root
-                
+
           commands:
             01_mount_gitaly_volume:
               command: source /etc/gitlab/mount_gitaly_volume.sh

--- a/templates/workload/gitlab-praefect-template.yaml
+++ b/templates/workload/gitlab-praefect-template.yaml
@@ -222,6 +222,18 @@ Resources:
             100_gitlab_yum_repo:
               command: curl https://packages.gitlab.com/install/repositories/gitlab/gitlab-ee/script.rpm.sh | bash
 
+            # 105_gitlab_distro_mapping:
+            #   command: !Sub |
+            #     IFS='.' read -r major minor patch <<< '${GitLabVersion}'; if [ ${major} -ge 15 ]; then sed -i 's/\\/el\\/7/\\/amazon\\/2/g' /etc/yum.repos.d/gitlab_gitlab*.repo; else sed -i 's/\\/amazon\\/2/\\/el\\/7/g' /etc/yum.repos.d/gitlab_gitlab*.repo; fi; yum clean all ; yum makecache;
+
+            105_gitlab_distro_mapping:
+              command:
+                Fn::Join:
+                  - ""
+                  - - "echo 'WARNING: ARM for Amazon Linux is not supported before GitLab 14.9.0 and this stack will fail if that combination is specified.'; IFS='.' read -r major minor patch <<< '"
+                    - Ref: "GitLabVersion"
+                    - "'; if [[ ${major} -ge 15 || (${major} -eq 14 && ${minor} -ge 9) ]]; then sed -i 's/\\/el\\/7/\\/amazon\\/2/g' /etc/yum.repos.d/gitlab_gitlab*.repo; else sed -i 's/\\/amazon\\/2/\\/el\\/7/g' /etc/yum.repos.d/gitlab_gitlab*.repo; fi; yum clean all; yum makecache;"
+
             200_yum_update:
               command: yum update -y --exclude=gitlab-ee*
         03_install_praefect:
@@ -244,6 +256,7 @@ Resources:
                 sidekiq['enable'] = false
                 gitlab_workhorse['enable'] = false
                 gitaly['enable'] = false
+                gitlab_kas['enable'] = false
 
                 # Prevent database connections during 'gitlab-ctl reconfigure'
                 gitlab_rails['rake_cache_clear'] = false

--- a/templates/workload/gitlab-template.yaml
+++ b/templates/workload/gitlab-template.yaml
@@ -146,10 +146,12 @@ Parameters:
     Type: String
   GitalyInstanceType:
     Type: String
-
   LatestAmazonLinuxAmi:
     Type: AWS::SSM::Parameter::Value<String>
     Default: /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2
+    AllowedValues:
+     - /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2
+     - /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-arm64-gp2
   PraefectPort:
     Type: Number
     Default: 2305


### PR DESCRIPTION
*Issue #, partially addresses #106

*Description of changes:*
- maps distro packages for post-14.9.0 to AL 2 to use new official packages
- maps distro packages for pre-14.9.0 to EL 7 to avoid breaking change when gitlab defaults change to AL2 packages
- Enables graviton to be specified for Gitaly and Prafect
- New parameter takes x86_64 or arm64
- New code in gitaly and praefect templates correctly map yum repos
- Fix: disable kas service on gitaly/praefect servers
