### PR TITLE
Add support for creating DNS records in existing Route53 hosted zone

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -35,8 +35,8 @@ tests:
       DomainName: devops.$[taskcat_random-string].com
       ConfigureContainerInsights: 'Yes'
       ConfigureGrafana: 'Yes'
-      CreateHostedZone: 'Yes'
       CacheMode: External
+      PublicDNS: CreateNew
       SMTPDomain: CreateNew
       ConfigureRunner: 'Yes'
       PrivilegedMode: 'Yes'
@@ -58,7 +58,7 @@ tests:
       SslCertificateIssuerEmail: gitlab@$[taskcat_random-string].com
       ConfigureContainerInsights: 'Yes'
       ConfigureGrafana: 'Yes'
-      CreateHostedZone: 'Yes'
+      PublicDNS: CreateNew
       SMTPDomain: CreateNew
       ConfigureRunner: 'No'
       PriviligedMode: 'No'
@@ -92,7 +92,7 @@ tests:
       SslCertificateIssuerEmail: gitlab@$[taskcat_random-string].com
       ConfigureContainerInsights: 'Yes'
       ConfigureGrafana: 'Yes'
-      CreateHostedZone: 'Yes'
+      PublicDNS: CreateNew
       SMTPDomain: CreateNew
       ConfigureRunner: 'No'
       PriviligedMode: 'No'

--- a/templates/gitlab-entry-existing-vpc.template.yaml
+++ b/templates/gitlab-entry-existing-vpc.template.yaml
@@ -224,7 +224,7 @@ Metadata:
       PublicDNS:
         default: Public DNS
       PublicHostedZoneId:
-        default: Public Hosted Zone Id
+        default: Public Hosted Zone ID
       CreateSslCertificate:
         default: Request AWS Certificate Manager SSL certificate
     # GitLab SMTP configuration
@@ -564,11 +564,11 @@ Parameters:
     AllowedValues: [ 'Disabled', 'UseExisting', 'CreateNew' ]
     Default: 'Disabled'
     Description: |
-      Choose "UseExisting" to provide public hosted zone Id where GitLab DNS records should be created. 
+      Choose "UseExisting" to provide public hosted zone ID where GitLab DNS records should be created. 
       Choose "CreateNew" to provision a new Route 53 public hosted zone with provided Domain Name and create GitLab DNS records there.
   PublicHostedZoneId:
     Type: String
-    Description: Provide Route 53 public hosted zone Id if you selected "UseExisting" above.
+    Description: Provide Route 53 public hosted zone ID if you selected "UseExisting" above.
     Default: ''
   CreateSslCertificate:
     Type: String

--- a/templates/gitlab-entry-existing-vpc.template.yaml
+++ b/templates/gitlab-entry-existing-vpc.template.yaml
@@ -91,7 +91,8 @@ Metadata:
           default: GitLab infrastructure configuration
         Parameters:
           - DomainName
-          - CreateHostedZone
+          - PublicDNS
+          - PublicHostedZoneId
           - CreateSslCertificate
       - Label:
           default: GitLab SMTP configuration
@@ -220,8 +221,10 @@ Metadata:
     # GitLab infrastructure configuration
       DomainName:
         default: GitLab DNS name
-      CreateHostedZone:
-        default: Create Route 53 hosted zone
+      PublicDNS:
+        default: Public DNS
+      PublicHostedZoneId:
+        default: Public Hosted Zone Id
       CreateSslCertificate:
         default: Request AWS Certificate Manager SSL certificate
     # GitLab SMTP configuration
@@ -556,11 +559,17 @@ Parameters:
   DomainName:
     Type: String
     Description: The domain name for the GitLab server.
-  CreateHostedZone:
+  PublicDNS:
     Type: String
-    Description: Choose "Yes" if you want to create Amazon Route 53 to manage DNS for GitLab domain.
-    AllowedValues: [ 'Yes', 'No' ]
-    Default: 'No'
+    AllowedValues: [ 'Disabled', 'UseExisting', 'CreateNew' ]
+    Default: 'Disabled'
+    Description: |
+      Choose "UseExisting" to provide public hosted zone Id where GitLab DNS records should be created. 
+      Choose "CreateNew" to provision a new Route 53 public hosted zone with provided Domain Name and create GitLab DNS records there.
+  PublicHostedZoneId:
+    Type: String
+    Description: Provide Route 53 public hosted zone Id if you selected "UseExisting" above.
+    Default: ''
   CreateSslCertificate:
     Type: String
     Description: Choose "Yes" if you want to request  AWS Certificate Manager SSL certificate for GitLab domain.
@@ -851,7 +860,8 @@ Resources:
         QSS3BucketRegion: !Ref QSS3BucketRegion
         # Infra properties
         DomainName: !Ref DomainName
-        CreateHostedZone: !Ref CreateHostedZone
+        PublicDNS: !Ref PublicDNS
+        PublicHostedZoneId: !Ref PublicHostedZoneId
         CreateSslCertificate: !Ref CreateSslCertificate
         EnvironmentName: !If [EmptyEnvironmentName, !Ref 'AWS::StackName', !Ref EnvironmentName]
         # Network properties

--- a/templates/gitlab-entry-new-vpc.template.yaml
+++ b/templates/gitlab-entry-new-vpc.template.yaml
@@ -91,7 +91,8 @@ Metadata:
           default: GitLab infrastructure configuration
         Parameters:
           - DomainName
-          - CreateHostedZone
+          - PublicDNS
+          - PublicHostedZoneId
           - CreateSslCertificate
       - Label:
           default: GitLab SMTP configuration
@@ -222,8 +223,10 @@ Metadata:
     # GitLab infrastructure configuration
       DomainName: 
         default: GitLab DNS name
-      CreateHostedZone: 
-        default: Create Route 53 hosted zone
+      PublicDNS:
+        default: Public DNS
+      PublicHostedZoneId:
+        default: Public Hosted Zone Id
       CreateSslCertificate: 
         default: Request AWS Certificate Manager SSL certificate
     # GitLab SMTP configuration
@@ -584,11 +587,17 @@ Parameters:
   DomainName:
     Type: String
     Description: The domain name for the GitLab server.
-  CreateHostedZone:
+  PublicDNS:
     Type: String
-    Description: Choose "Yes" if you want to create Amazon Route 53 to manage DNS for GitLab domain.
-    AllowedValues: [ 'Yes', 'No' ]
-    Default: 'No'
+    AllowedValues: [ 'Disabled', 'UseExisting', 'CreateNew' ]
+    Default: 'Disabled'
+    Description: |
+      Choose "UseExisting" to provide public hosted zone Id where GitLab DNS records should be created. 
+      Choose "CreateNew" to provision a new Route 53 public hosted zone with provided Domain Name and create GitLab DNS records there.
+  PublicHostedZoneId:
+    Type: String
+    Description: Provide Route 53 public hosted zone Id if you selected "UseExisting" above.
+    Default: ''
   CreateSslCertificate:
     Type: String
     Description: Choose "Yes" if you want to request  AWS Certificate Manager SSL certificate for GitLab domain.
@@ -873,7 +882,8 @@ Resources:
         CacheNodeType: !Ref CacheNodeType
         # Infra Parameters
         DomainName: !Ref DomainName
-        CreateHostedZone: !Ref CreateHostedZone
+        PublicDNS: !Ref PublicDNS
+        PublicHostedZoneId: !Ref PublicHostedZoneId
         CreateSslCertificate: !Ref CreateSslCertificate
         # SMTP Parameters
         SMTPDomain: !Ref SMTPDomain

--- a/templates/gitlab-entry-new-vpc.template.yaml
+++ b/templates/gitlab-entry-new-vpc.template.yaml
@@ -592,11 +592,11 @@ Parameters:
     AllowedValues: [ 'Disabled', 'UseExisting', 'CreateNew' ]
     Default: 'Disabled'
     Description: |
-      Choose "UseExisting" to provide public hosted zone Id where GitLab DNS records should be created. 
+      Choose "UseExisting" to provide public hosted zone ID where GitLab DNS records should be created. 
       Choose "CreateNew" to provision a new Route 53 public hosted zone with provided Domain Name and create GitLab DNS records there.
   PublicHostedZoneId:
     Type: String
-    Description: Provide Route 53 public hosted zone Id if you selected "UseExisting" above.
+    Description: Provide Route 53 public hosted zone ID if you selected "UseExisting" above.
     Default: ''
   CreateSslCertificate:
     Type: String

--- a/templates/gitlab-entry-new-vpc.template.yaml
+++ b/templates/gitlab-entry-new-vpc.template.yaml
@@ -226,7 +226,7 @@ Metadata:
       PublicDNS:
         default: Public DNS
       PublicHostedZoneId:
-        default: Public Hosted Zone Id
+        default: Public Hosted Zone ID
       CreateSslCertificate: 
         default: Request AWS Certificate Manager SSL certificate
     # GitLab SMTP configuration

--- a/templates/workload/gitlab-infra-template.yaml
+++ b/templates/workload/gitlab-infra-template.yaml
@@ -23,9 +23,11 @@ Parameters:
 
   DomainName:
     Type: String
-  CreateHostedZone:
+  PublicDNS:
     Type: String
-    AllowedValues: ["Yes", "No"]
+    AllowedValues: [ 'Disabled', 'UseExisting', 'CreateNew' ]
+  PublicHostedZoneId:
+    Type: String
   CreateEmailDomain:
     Type: String
     AllowedValues: ["Yes", "No"]
@@ -51,14 +53,15 @@ Parameters:
 
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
-  HostedZoneRequested: !Equals  [!Ref CreateHostedZone, 'Yes']
+  HostedZoneInUse: !Not [!Equals  [!Ref PublicDNS, 'Disabled']]
+  HostedZoneToBeCreated: !Equals  [!Ref PublicDNS, 'CreateNew']
   EmailDomainRequested: !Equals [!Ref CreateEmailDomain, 'Yes']
   EmailDomainWithRoute53Validation: !And
     - !Equals [!Ref CreateEmailDomain, 'Yes']
-    - !Condition HostedZoneRequested
+    - !Condition HostedZoneInUse
   CertificateRequested: !And
     - !Equals [!Ref CreateSslCertificate, 'Yes']
-    - !Condition HostedZoneRequested
+    - !Condition HostedZoneInUse
 
 Resources:
 
@@ -90,7 +93,7 @@ Resources:
 # 1. Create a new hosted zone for subdomain
   HostedZone:
     Type: AWS::Route53::HostedZone
-    Condition: HostedZoneRequested
+    Condition: HostedZoneToBeCreated
     Properties:
       Name: !Sub "${DomainName}."
   # Always create private hosted zone, even if public is not requested
@@ -285,7 +288,7 @@ Resources:
 
   HostedZoneNameParameter:
     Type: AWS::SSM::Parameter
-    Condition: HostedZoneRequested
+    Condition: HostedZoneInUse
     Properties:
       Type: String
       Name: !Sub '/quickstart/gitlab/${EnvironmentName}/infra/hosted-zone-name'
@@ -293,12 +296,15 @@ Resources:
 
   HostedZoneIdParameter:
     Type: AWS::SSM::Parameter
-    Condition: HostedZoneRequested
+    Condition: HostedZoneInUse
     Properties:
       Type: String
       Name: !Sub '/quickstart/gitlab/${EnvironmentName}/infra/hosted-zone-id'
       Description: "GitLab Route53 public hosted zone ID"
-      Value: !Ref HostedZone
+      Value: !If
+      - HostedZoneToBeCreated
+      - !Ref HostedZone
+      - !Ref PublicHostedZoneId 
 
   PrivateHostedZoneIdParameter:
     Type: AWS::SSM::Parameter
@@ -344,7 +350,10 @@ Outputs:
     Condition: EmailDomainRequested
     Value: !Ref SmtpCredentialsSecret
   HostedZoneId:
-    Condition: HostedZoneRequested
-    Value: !Ref HostedZone
+    Condition: HostedZoneInUse
+    Value: !If
+      - HostedZoneToBeCreated
+      - !Ref HostedZone
+      - !Ref PublicHostedZoneId    
   PrivateHostedZoneId:
     Value: !Ref PrivateHostedZone

--- a/templates/workload/gitlab-infra-template.yaml
+++ b/templates/workload/gitlab-infra-template.yaml
@@ -114,7 +114,7 @@ Resources:
       ValidationMethod: DNS
       DomainValidationOptions:
         - DomainName: !Sub "*.${DomainName}"
-          HostedZoneId: !Ref HostedZone
+          HostedZoneId: !If [HostedZoneToBeCreated, !Ref HostedZone, !Ref PublicHostedZoneId]
 
 
   CleanupACMDNSValidationLambdaRole:
@@ -147,7 +147,7 @@ Resources:
                   - route53:ChangeResourceRecordSets
                 Resource: !Sub
                   - "arn:${AWS::Partition}:route53:::hostedzone/${HostedZoneID}"
-                  - HostedZoneID: !Ref HostedZone
+                  - HostedZoneID: !If [HostedZoneToBeCreated, !Ref HostedZone, !Ref PublicHostedZoneId]
 
   CleanupACMDNSValidationLambdaFunction:
     Type: AWS::Lambda::Function
@@ -166,7 +166,7 @@ Resources:
     Properties:
       ServiceToken: !GetAtt "CleanupACMDNSValidationLambdaFunction.Arn"
       ACMArn: !Ref SslCertificate
-      HostedZoneId: !Ref HostedZone
+      HostedZoneId: !If [HostedZoneToBeCreated, !Ref HostedZone, !Ref PublicHostedZoneId]
 
 # 3. Define the Custom::SES_Domain's Lambda Function via a nested stack.
   CfnSESResources:
@@ -206,7 +206,7 @@ Resources:
     Type: AWS::Route53::RecordSetGroup
     Condition: EmailDomainWithRoute53Validation
     Properties:
-      HostedZoneId: !Ref HostedZone
+      HostedZoneId: !If [HostedZoneToBeCreated, !Ref HostedZone, !Ref PublicHostedZoneId]
       # The Route53RecordSets attribute specifies all DNS records needed:
       RecordSets: !GetAtt SESDomain.Route53RecordSets
 

--- a/templates/workload/gitlab-template.yaml
+++ b/templates/workload/gitlab-template.yaml
@@ -14,9 +14,11 @@ Parameters:
 # Infra Parameters
   DomainName:
     Type: String
-  CreateHostedZone:
+  PublicDNS:
     Type: String
-    AllowedValues: [ 'Yes', 'No' ]
+    AllowedValues: [ 'Disabled', 'UseExisting', 'CreateNew' ]
+  PublicHostedZoneId:
+    Type: String
   CreateSslCertificate:
     Type: String
     AllowedValues: [ 'Yes', 'No' ]
@@ -195,8 +197,8 @@ Conditions:
   ConfigureGrafana: !Equals [!Ref ConfigureGrafana, 'Yes']
   OutgoingEmailEnabled: !Not [!Equals [!Ref SMTPDomain, 'Disabled']]
   CreateEmailDomain: !Equals [!Ref SMTPDomain, 'CreateNew']
-  CreateHostedZone: !Equals [!Ref CreateHostedZone, 'Yes']
-  AcmIngressConfigured: !And [!Equals [!Ref CreateHostedZone, 'Yes'], !Equals [!Ref CreateSslCertificate, 'Yes']] 
+  HostedZoneInUse: !Not [!Equals  [!Ref PublicDNS, 'Disabled']]
+  AcmIngressConfigured: !And [!Equals [!Ref CreateSslCertificate, 'Yes'], !Condition HostedZoneInUse] 
   HelmChartNamespaceCreate: !Equals [!Ref HelmChartNamespaceCreate, 'CreateNew']
   CreateCacheCluster: !Equals [!Ref CacheMode, 'External']
   ConfigureRunner: !Equals [!Ref ConfigureRunner, 'Yes']
@@ -268,7 +270,8 @@ Resources:
         VPCCIDR: !Ref VPCCIDR
         PraefectPort: !Ref PraefectPort
         DomainName: !Ref DomainName
-        CreateHostedZone: !Ref CreateHostedZone
+        PublicDNS: !Ref PublicDNS
+        PublicHostedZoneId: !Ref PublicHostedZoneId
         CreateEmailDomain: !If [CreateEmailDomain, 'Yes', 'No'] 
         CreateSslCertificate: !Ref CreateSslCertificate
         FunctionsBucketName: !GetAtt Functions.Outputs.FunctionsBucketName
@@ -643,7 +646,7 @@ Resources:
         HelmChartNamespace: !Ref HelmChartNamespace
         HelmChartName: !Ref HelmChartName
         DomainName: !Ref DomainName
-        HostedZoneId: !If [CreateHostedZone, !GetAtt Infrastructure.Outputs.HostedZoneId, '']
+        HostedZoneId: !If [HostedZoneInUse, !GetAtt Infrastructure.Outputs.HostedZoneId, '']
         PrivateHostedZoneId: !GetAtt Infrastructure.Outputs.PrivateHostedZoneId
         EnvironmentName: !Ref EnvironmentName
         ConfigureGrafana: !Ref ConfigureGrafana


### PR DESCRIPTION
*Issue #, if available:*
#37 

*Description of changes:*
Two new parameters were added to the QS to support different types of DNS configuration:
```yaml
  PublicDNS:
    Type: String
    AllowedValues: [ 'Disabled', 'UseExisting', 'CreateNew' ]
    Default: 'Disabled'
    Description: |
      Choose "UseExisting" to provide public hosted zone Id where GitLab DNS records should be created. 
      Choose "CreateNew" to provision a new Route 53 public hosted zone with provided Domain Name and create GitLab DNS records there.
  PublicHostedZoneId:
    Type: String
    Description: Provide Route 53 public hosted zone Id if you selected "UseExisting" above.
    Default: ''
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
