### PR TITLE
Add update/replace + delete k8s resource policies

### DIFF
--- a/templates/workload/gitlab-secrets-template.yaml
+++ b/templates/workload/gitlab-secrets-template.yaml
@@ -93,6 +93,8 @@ Resources:
 
   DatabaseSecret:
     Type: AWSQS::Kubernetes::Resource
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Retain
     Properties:
       ClusterName: !Ref KubeClusterName
       Namespace: !Ref HelmChartNamespace
@@ -114,6 +116,8 @@ Resources:
 
   ObjectStorageSecret:
     Type: AWSQS::Kubernetes::Resource
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Retain
     Properties:
       ClusterName: !Ref KubeClusterName
       Namespace: !Ref HelmChartNamespace
@@ -160,6 +164,8 @@ Resources:
   SmtpSecret:
     Type: AWSQS::Kubernetes::Resource
     Condition: SmtpEnabled
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Retain
     Properties:
       ClusterName: !Ref KubeClusterName
       Namespace: !Ref HelmChartNamespace
@@ -181,6 +187,8 @@ Resources:
 
   GitLabShellSecret:
     Type: AWSQS::Kubernetes::Resource
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Retain
     Properties:
       ClusterName: !Ref KubeClusterName
       Namespace: !Ref HelmChartNamespace
@@ -202,6 +210,8 @@ Resources:
 
   GitLabGitalySecret:
     Type: AWSQS::Kubernetes::Resource
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Retain
     Properties:
       ClusterName: !Ref KubeClusterName
       Namespace: !Ref HelmChartNamespace
@@ -223,6 +233,8 @@ Resources:
 
   RunnerTokenSecret:
     Type: AWSQS::Kubernetes::Resource
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Retain
     Properties:
       ClusterName: !Ref KubeClusterName
       Namespace: !Ref HelmChartNamespace

--- a/templates/workload/gitlab-telemetry-template.yaml
+++ b/templates/workload/gitlab-telemetry-template.yaml
@@ -25,6 +25,8 @@ Resources:
   # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-metrics.html
   CloudWatchNamespace:
     Type: AWSQS::Kubernetes::Resource
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Retain
     Properties:
       ClusterName: !Ref ClusterName
       Namespace: default
@@ -39,6 +41,8 @@ Resources:
   CloudWatchServiceAccount:
     Type: AWSQS::Kubernetes::Resource
     DependsOn: CloudWatchNamespace
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Retain
     Properties:
       ClusterName: !Ref ClusterName
       Namespace: amazon-cloudwatch
@@ -52,6 +56,8 @@ Resources:
   CloudWatchClusterRole:
     Type: AWSQS::Kubernetes::Resource
     DependsOn: CloudWatchServiceAccount
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Retain
     Properties:
       ClusterName: !Ref ClusterName
       Namespace: default
@@ -84,6 +90,8 @@ Resources:
   CloudWatchClusterRoleBinding:
     Type: AWSQS::Kubernetes::Resource
     DependsOn: CloudWatchClusterRole
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Retain
     Properties:
       ClusterName: !Ref ClusterName
       Namespace: default
@@ -104,6 +112,8 @@ Resources:
   CloudWatchAgentConfigMap:
     Type: AWSQS::Kubernetes::Resource
     DependsOn: CloudWatchClusterRoleBinding
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Retain
     Properties:
       ClusterName: !Ref ClusterName
       Namespace: amazon-cloudwatch
@@ -134,6 +144,8 @@ Resources:
   CloudWatchAgentDaemonSet:
     Type: AWSQS::Kubernetes::Resource
     DependsOn: CloudWatchAgentConfigMap
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Retain
     Properties:
       ClusterName: !Ref ClusterName
       Namespace: amazon-cloudwatch
@@ -230,6 +242,8 @@ Resources:
   CloudWatchConfigMap:
     Type: AWSQS::Kubernetes::Resource
     DependsOn: CloudWatchNamespace
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Retain
     Properties:
       ClusterName: !Ref ClusterName
       Namespace: amazon-cloudwatch
@@ -251,6 +265,8 @@ Resources:
   FluentdServiceAccount:
     Type: AWSQS::Kubernetes::Resource
     DependsOn: CloudWatchConfigMap
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Retain
     Properties:
       ClusterName: !Ref ClusterName
       Namespace: amazon-cloudwatch
@@ -264,6 +280,8 @@ Resources:
   FluentdClusterRole:
     Type: AWSQS::Kubernetes::Resource
     DependsOn: FluentdServiceAccount
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Retain
     Properties:
       ClusterName: !Ref ClusterName
       Namespace: default
@@ -283,6 +301,8 @@ Resources:
   FluentdClusterRoleBinding:
     Type: AWSQS::Kubernetes::Resource
     DependsOn: FluentdClusterRole
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Retain
     Properties:
       ClusterName: !Ref ClusterName
       Namespace: default
@@ -303,6 +323,8 @@ Resources:
   FluentdConfigMap:
     Type: AWSQS::Kubernetes::Resource
     DependsOn: FluentdClusterRoleBinding
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Retain
     Properties:
       ClusterName: !Ref ClusterName
       Namespace: amazon-cloudwatch
@@ -624,6 +646,8 @@ Resources:
   FluentdDaemonSet:
     Type: AWSQS::Kubernetes::Resource
     DependsOn: FluentdConfigMap
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Retain
     Properties:
       ClusterName: !Ref ClusterName
       Namespace: amazon-cloudwatch


### PR DESCRIPTION
* Workaround for sporadic stack delete race condition for `AWSQS::Kubernetes::Resource` resources that causes stack deletion failure and requires manual intervention

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
